### PR TITLE
improve logging output (prefixes, colors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/getdock/pptr-mock-server#readme",
   "dependencies": {
+    "chalk": "^2.4.1",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/src/handle-request.js
+++ b/src/handle-request.js
@@ -1,10 +1,21 @@
 import isFunction from 'lodash/fp/isFunction';
 import lowerCase from 'lodash/fp/lowerCase';
 import findLast from 'lodash/fp/findLast';
+import chalk from 'chalk';
 
 import sleep from './sleep';
 
 const {URL} = require('url');
+
+const consolePrefix = `[${chalk.blue('pptr-mock-server')}]`;
+
+function formatRequest(request) {
+  return chalk.green(`${request.method()} ${request.url()}`);
+}
+
+function warn(message) {
+  console.warn(`${consolePrefix} [warning] ${message}`);
+}
 
 export default async function handleRequest(
   request,
@@ -54,7 +65,11 @@ export default async function handleRequest(
     if (onApiRequest) {
       onApiRequest(request);
     } else {
-      console.warn(`Unexpected api call! ${request.method()} ${requestUrlStr}`);
+      warn(
+        `Unhandled api request! ${formatRequest(
+          request
+        )}. Responding with 200 OK {}.`
+      );
       request.respond({
         status: 200,
         contentType: 'application/json',
@@ -76,7 +91,7 @@ export default async function handleRequest(
     if (onRequest) {
       onRequest(request);
     } else {
-      console.log(`${request.method()} ${requestUrlStr} aborted`);
+      warn(`Unhandled external request! ${formatRequest(request)}. Aborting.`);
       request.abort();
     }
   }

--- a/src/handle-request.test.js
+++ b/src/handle-request.test.js
@@ -26,8 +26,8 @@ describe('handle request', () => {
       },
     ];
 
-    request.url.mockReturnValueOnce(endpoint);
-    request.method.mockReturnValueOnce('GET');
+    request.url.mockReturnValue(endpoint);
+    request.method.mockReturnValue('GET');
 
     handleRequest(request, config, handlers);
 
@@ -52,8 +52,8 @@ describe('handle request', () => {
       },
     ];
 
-    request.url.mockReturnValueOnce(endpoint + '?query');
-    request.method.mockReturnValueOnce('GET');
+    request.url.mockReturnValue(endpoint + '?query');
+    request.method.mockReturnValue('GET');
 
     handleRequest(request, config, handlers);
 
@@ -75,8 +75,8 @@ describe('handle request', () => {
       },
     ];
 
-    request.url.mockReturnValueOnce(endpoint);
-    request.method.mockReturnValueOnce('GET');
+    request.url.mockReturnValue(endpoint);
+    request.method.mockReturnValue('GET');
 
     handleRequest(request, config, handlers);
 
@@ -93,8 +93,8 @@ describe('handle request', () => {
       },
     ];
 
-    request.url.mockReturnValueOnce(endpoint);
-    request.method.mockReturnValueOnce('GET');
+    request.url.mockReturnValue(endpoint);
+    request.method.mockReturnValue('GET');
 
     await handleRequest(request, config, handlers);
 
@@ -102,8 +102,8 @@ describe('handle request', () => {
   });
 
   test('if there is no match, but endpoint starts with base api url', () => {
-    request.url.mockReturnValueOnce(endpoint);
-    request.method.mockReturnValueOnce('GET');
+    request.url.mockReturnValue(endpoint);
+    request.method.mockReturnValue('GET');
 
     handleRequest(request, config);
 
@@ -120,8 +120,8 @@ describe('handle request', () => {
 });
 
 test('abort all unhandled requests', () => {
-  request.url.mockReturnValueOnce('http://foo');
-  request.method.mockReturnValueOnce('GET');
+  request.url.mockReturnValue('http://foo');
+  request.method.mockReturnValue('GET');
 
   handleRequest(request, config);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,7 +1188,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:


### PR DESCRIPTION
Add prefix, colors, and a bit more explanation to console warnings.

Before:
<img width="504" alt="screen shot 2018-09-15 at 15 49 24" src="https://user-images.githubusercontent.com/1196011/45586365-f667c580-b8fe-11e8-9dae-92a5a0735274.png">

After:
<img width="1003" alt="screen shot 2018-09-15 at 15 46 42" src="https://user-images.githubusercontent.com/1196011/45586357-bd2f5580-b8fe-11e8-9923-9b7938969648.png">

Side changes:
- optimize tests (do not use `Once`, since there might be several calls needed)