### PR TITLE
preserve default request handling logic 

### DIFF
--- a/api.md
+++ b/api.md
@@ -56,14 +56,17 @@ Type: [Object][13]
 -   `baseApiUrl` **[string][17]** Base api url. By default all requests matching
     base api url are responded with 200 status and empty body, but you will see a
     warning in output.
--   `onRequest` **function (PuppeteerRequest)** Optional callback to be executed for any
-    unhandled request. By default requests are aborted.
--   `onAppRequest` **function (PuppeteerRequest)** Optional callback to be executed for any
-    unhandled app request, i.e. request matching `baseAppUrl` option. By default
-    requests are continued.
--   `onApiRequest` **function (PuppeteerRequest)** Optional callback to be executed for any
-    unhandled api request, i.e. request matching `baseApiUrl` option. By default
-    requests are responded with `200 OK {}` for convenience.
+-   `onRequest` **function (PuppeteerRequest)** Optional callback to be
+    executed for any unhandled request. By default requests are aborted if this
+    callback is not provided or returns falsy.
+-   `onAppRequest` **function (PuppeteerRequest)** Optional callback to be
+    executed for any unhandled app request, i.e. request matching `baseAppUrl`
+    option. By default requests are continued if this callback is not provided or
+    returns falsy.
+-   `onApiRequest` **function (PuppeteerRequest)** Optional callback to be
+    executed for any unhandled api request, i.e. request matching `baseApiUrl`
+    option. By default requests are responded with `200 OK {}` for convenience if
+    this callback is not provided or returns falsy.
 
 ## MockRequest
 

--- a/src/handle-request.js
+++ b/src/handle-request.js
@@ -62,9 +62,11 @@ export default async function handleRequest(
       });
     }
   } else if (requestUrlStr.startsWith(baseApiUrl)) {
+    let apiRequestHandled;
     if (onApiRequest) {
-      onApiRequest(request);
-    } else {
+      apiRequestHandled = onApiRequest(request);
+    }
+    if (!apiRequestHandled) {
       warn(
         `Unhandled api request! ${formatRequest(
           request
@@ -82,15 +84,19 @@ export default async function handleRequest(
     }
     return true;
   } else if (requestUrlStr.startsWith(baseAppUrl)) {
+    let appRequestHandled;
     if (onAppRequest) {
-      onAppRequest(request);
-    } else {
+      appRequestHandled = onAppRequest(request);
+    }
+    if (!appRequestHandled) {
       request.continue();
     }
   } else {
+    let requestHandled;
     if (onRequest) {
-      onRequest(request);
-    } else {
+      requestHandled = onRequest(request);
+    }
+    if (!requestHandled) {
       warn(`Unhandled external request! ${formatRequest(request)}. Aborting.`);
       request.abort();
     }

--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -56,12 +56,15 @@ export default function MockServer() {
  * @property {string} baseApiUrl Base api url. By default all requests matching
  * base api url are responded with 200 status and empty body, but you will see a
  * warning in output.
- * @property {function(PuppeteerRequest)} onRequest Optional callback to be executed for any
- * unhandled request. By default requests are aborted.
- * @property {function(PuppeteerRequest)} onAppRequest Optional callback to be executed for any
- * unhandled app request, i.e. request matching `baseAppUrl` option. By default
- * requests are continued.
- * @property {function(PuppeteerRequest)} onApiRequest Optional callback to be executed for any
- * unhandled api request, i.e. request matching `baseApiUrl` option. By default
- * requests are responded with `200 OK {}` for convenience.
+ * @property {function(PuppeteerRequest)} onRequest Optional callback to be
+ * executed for any unhandled request. By default requests are aborted if this
+ * callback is not provided or returns falsy.
+ * @property {function(PuppeteerRequest)} onAppRequest Optional callback to be
+ * executed for any unhandled app request, i.e. request matching `baseAppUrl`
+ * option. By default requests are continued if this callback is not provided or
+ * returns falsy.
+ * @property {function(PuppeteerRequest)} onApiRequest Optional callback to be
+ * executed for any unhandled api request, i.e. request matching `baseApiUrl`
+ * option. By default requests are responded with `200 OK {}` for convenience if
+ * this callback is not provided or returns falsy.
  */


### PR DESCRIPTION
Preserve default request handling logic even if custom handler is provided.

When `onRequest`, or `onAppRequest`, or `onApiRequest` callback method is provided, it can return truthy/falsy. If falsy value is retuned, then default request handling logic is used. This allows to not duplicate default logic in custom request handler.